### PR TITLE
Convert to lookup() and new installer names

### DIFF
--- a/manifests/appserver.pp
+++ b/manifests/appserver.pp
@@ -10,15 +10,15 @@ class io_erpfirewall::appserver () inherits io_erpfirewall {
     case $library_platform {
       default: {
         exec { "Unix ERP Firewall Application Server Install: ${domain_name} ${app_deploy_location}":
-          command => "${archive_location}/AppServer/Unix/gh_fwappserv.bin ${app_deploy_location}",
+          command => "${archive_location}/AppServer/Unix/asp_app.bin ${app_deploy_location}",
           creates => "${app_deploy_location}/appserv/classes/gs-util.jar",
           user    => $psft_install_user_name,
         }
       }
       'Windows': {
         exec { "Windows ERP Firewall Application Server Install: ${domain_name} ${app_deploy_location}":
-          command => "copy-item ${archive_location}/AppServer/Windows/setup.exe \${Env:temp};
-                \${Env:temp}/setup.exe `
+          command => "copy-item ${archive_location}/AppServer/Windows/asp_app.exe \${Env:temp};
+                \${Env:temp}/asp_app.exe `
                 /log=\"\${Env:TEMP}/appserver-installation.log\" `
                 /verysilent `
                 /suppressmsgboxes `

--- a/manifests/appserver.pp
+++ b/manifests/appserver.pp
@@ -6,30 +6,30 @@ class io_erpfirewall::appserver (
   $appserver_domain_list        = $io_erpfirewall::appserver_domain_list,
   $library_platform             = $io_erpfirewall::library_platform,
   $archive_location             = $io_erpfirewall::archive_location,
-  $ps_config_home               = $io_erpfirewall::ps_config_home,
+  $ps_home_location             = $io_erpfirewall::ps_home_location,
 ) inherits io_erpfirewall {
   notify { 'Deploying appserver files for ERP Firewall': }
 
   $appserver_domain_list.each |$domain_name, $appserver_domain_info| {
-    notify {"${domain_name} App Deploy Location: ${ps_config_home}": }
+    notify {"${domain_name} App Deploy Location: ${ps_home_location}": }
 
     case $library_platform {
       default: {
-        exec { "Unix ERP Firewall Application Server Install: ${domain_name} ${ps_config_home}":
-          command => "${archive_location}/AppServer/Unix/asp_app.bin ${ps_config_home}",
-          creates => "${ps_config_home}/appserv/classes/gs-util.jar",
+        exec { "Unix ERP Firewall Application Server Install: ${domain_name} ${ps_home_location}":
+          command => "${archive_location}/AppServer/Unix/asp_app.bin ${ps_home_location}",
+          creates => "${ps_home_location}/appserv/classes/gs-util.jar",
           user    => $psft_runtime_user_name,
         }
       }
       'Windows': {
-        exec { "Windows ERP Firewall Application Server Install: ${domain_name} ${ps_config_home}":
+        exec { "Windows ERP Firewall Application Server Install: ${domain_name} ${ps_home_location}":
           command  => "copy-item ${archive_location}/AppServer/Windows/asp_app.exe \${Env:temp};
                 \${Env:temp}/asp_app.exe `
                 /log=\"\${Env:TEMP}/appserver-installation.log\" `
                 /verysilent `
                 /suppressmsgboxes `
-                /pshome=\"${ps_config_home}\"",
-          creates  => "${ps_config_home}/classes/gs-util.jar",
+                /pshome=\"${ps_home_location}\"",
+          creates  => "${ps_home_location}/classes/gs-util.jar",
           provider => powershell,
         }
       }

--- a/manifests/appserver.pp
+++ b/manifests/appserver.pp
@@ -1,29 +1,35 @@
 # Class: io_erpfirewall::appserver
 #
 #
-class io_erpfirewall::appserver () inherits io_erpfirewall {
+class io_erpfirewall::appserver (
+  $psft_runtime_user_name       = $io_erpfirewall::psft_runtime_user_name,
+  $appserver_domain_list        = $io_erpfirewall::appserver_domain_list,
+  $library_platform             = $io_erpfirewall::library_platform,
+  $archive_location             = $io_erpfirewall::archive_location,
+  $ps_config_home               = $io_erpfirewall::ps_config_home,
+) inherits io_erpfirewall {
   notify { 'Deploying appserver files for ERP Firewall': }
 
   $appserver_domain_list.each |$domain_name, $appserver_domain_info| {
-    notify {"${domain_name} App Deploy Location: ${app_deploy_location}": }
+    notify {"${domain_name} App Deploy Location: ${ps_config_home}": }
 
     case $library_platform {
       default: {
-        exec { "Unix ERP Firewall Application Server Install: ${domain_name} ${app_deploy_location}":
-          command => "${archive_location}/AppServer/Unix/asp_app.bin ${app_deploy_location}",
-          creates => "${app_deploy_location}/appserv/classes/gs-util.jar",
-          user    => $psft_install_user_name,
+        exec { "Unix ERP Firewall Application Server Install: ${domain_name} ${ps_config_home}":
+          command => "${archive_location}/AppServer/Unix/asp_app.bin ${ps_config_home}",
+          creates => "${ps_config_home}/appserv/classes/gs-util.jar",
+          user    => $psft_runtime_user_name,
         }
       }
       'Windows': {
-        exec { "Windows ERP Firewall Application Server Install: ${domain_name} ${app_deploy_location}":
-          command => "copy-item ${archive_location}/AppServer/Windows/asp_app.exe \${Env:temp};
+        exec { "Windows ERP Firewall Application Server Install: ${domain_name} ${ps_config_home}":
+          command  => "copy-item ${archive_location}/AppServer/Windows/asp_app.exe \${Env:temp};
                 \${Env:temp}/asp_app.exe `
                 /log=\"\${Env:TEMP}/appserver-installation.log\" `
                 /verysilent `
                 /suppressmsgboxes `
-                /pshome=\"${app_deploy_location}\"",
-          creates => "${app_deploy_location}/classes/gs-util.jar",
+                /pshome=\"${ps_config_home}\"",
+          creates  => "${ps_config_home}/classes/gs-util.jar",
           provider => powershell,
         }
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,8 @@ class io_erpfirewall (
   $ps_cust_home_location     = lookup('ps_cust_home_location', undef, undef, ''),
   $ps_config_home            = lookup('ps_config_home', undef, undef, ''),
   $archive_location          = lookup('archive_location', undef, undef, ''),
-  $redeploy_firewall         = lookup('redeploy_firewall', undef, undef, '')
+  $redeploy_firewall         = lookup('redeploy_firewall', undef, undef, ''),
+  $java_home                 = lookup('jdk_location', undef, undef, '')
 ) {
 
   case $::osfamily {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,18 +1,18 @@
 class io_erpfirewall (
-  $ensure                    = hiera('ensure', 'present'),
-  $psft_runtime_user_name    = hiera('psft_runtime_user_name', 'psadm2'),
-  $oracle_install_group_name = hiera('oracle_install_group_name', 'oinstall'),
-  $pia_domain_list           = hiera_hash('pia_domain_list', undef),
-  $appserver_domain_list     = hiera_hash('appserver_domain_list', undef),
+  $ensure                    = lookup('ensure', undef, undef, 'present'),
+  $psft_runtime_user_name    = lookup('psft_runtime_user_name', undef, undef, 'psadm2'),
+  $oracle_install_group_name = lookup('oracle_install_group_name', undef, undef, 'oinstall'),
+  $pia_domain_list           = lookup('pia_domain_list', undef, undef, ''),
+  $appserver_domain_list     = lookup('appserver_domain_list', undef, undef, ''),
   $library_base              = undef,
   $pia                       = undef,
   $appserver                 = undef,
   $app_deploy_location       = undef,
-  $ps_home_location          = hiera('ps_home_location', undef),
-  $ps_cust_home_location     = hiera('ps_cust_home_location', undef),
-  $ps_config_home            = hiera('ps_config_home', undef),
-  $archive_location          = hiera('archive_location', undef),
-  $redeploy_firewall         = hiera('redeploy_firewall', undef)
+  $ps_home_location          = lookup('ps_home_location', undef, undef, ''),
+  $ps_cust_home_location     = lookup('ps_cust_home_location', undef, undef, ''),
+  $ps_config_home            = lookup('ps_config_home', undef, undef, ''),
+  $archive_location          = lookup('archive_location', undef, undef, ''),
+  $redeploy_firewall         = lookup('redeploy_firewall', undef, undef, '')
 ) {
 
   case $::osfamily {

--- a/manifests/pia.pp
+++ b/manifests/pia.pp
@@ -16,7 +16,7 @@ class io_erpfirewall::pia (
 
   $pia_domain_list.each |$domain_name, $pia_domain_info| {
 
-    $udomain_name = upcase($domain_name)
+    #$udomain_name = upcase($domain_name)
 
     case $library_platform {
       default: {
@@ -54,7 +54,7 @@ class io_erpfirewall::pia (
           provider => powershell,
         }
         -> exec { "${domain_name}_install_erpfirwall":
-          command  => "& \"c:/temp/asp_web.exe\" /log=\"c:/temp/erpfirewall-webserver-installation.log\" /verysilent /suppressmsgboxes /pshome=\"${ps_config_home}\" /piadomain=\"${udomain_name}\"; sleep 30",
+          command  => "& \"c:/temp/asp_web.exe\" /log=\"c:/temp/erpfirewall-webserver-installation.log\" /verysilent /suppressmsgboxes /pshome=\"${ps_config_home}\" /piadomain=\"${domain_name}\"; sleep 30",
           creates  => "${ps_config_home}/webserv/${domain_name}/applications/peoplesoft/PORTAL.war/WEB-INF/gsdocs",
           provider => powershell,
         }

--- a/manifests/pia.pp
+++ b/manifests/pia.pp
@@ -75,7 +75,7 @@ class io_erpfirewall::pia (
     $site_list.each |$site_name, $site_info| {
 
         $disable_file   = "${ps_config_home}/webserv/${domain_name}/applications/peoplesoft/PORTAL.war/WEB-INF/gsdocs/site_${site_name}_disabled.txt"
-        file {"disable_erpfirewall_$site_name":
+        file {"disable_erpfirewall_$domain_name_$site_name":
           path  => $disable_file,
           ensure  => $site_info['appsian_disable'],
         }

--- a/manifests/pia.pp
+++ b/manifests/pia.pp
@@ -9,6 +9,7 @@ class io_erpfirewall::pia (
   $ps_config_home         = $io_erpfirewall::ps_config_home,
   $ps_home_location       = $io_erpfirewall::ps_home_location,
   $redeploy_firewall      = $io_erpfirewall::redeploy_firewall,
+  $jdk_location           = $io_erpfirewall::jdk_location,
 ) inherits io_erpfirewall {
   notify { 'Deploying PIA files for ERP Firewall': }
 

--- a/manifests/pia.pp
+++ b/manifests/pia.pp
@@ -75,9 +75,9 @@ class io_erpfirewall::pia (
     $site_list.each |$site_name, $site_info| {
 
         $disable_file   = "${ps_config_home}/webserv/${domain_name}/applications/peoplesoft/PORTAL.war/WEB-INF/gsdocs/site_${site_name}_disabled.txt"
-        file {"disable_erpfirewall_$domain_name_$site_name":
-          path  => $disable_file,
-          ensure  => $site_info['appsian_disable'],
+        file {"disable_erpfirewall_${domain_name}_${site_name}":
+          ensure => $site_info['appsian_disable'],
+          path   => $disable_file,
         }
 
     } # end site_list

--- a/manifests/pia.pp
+++ b/manifests/pia.pp
@@ -21,7 +21,7 @@ class io_erpfirewall::pia (
     case $library_platform {
       default: {
         exec { "install_erpfirewall-${domain_name}":
-          command => "/bin/su -m -s /bin/bash - ${psft_runtime_user_name} -c \"${archive_location}/WebServer/Unix/gh_firewall_web.bin ${ps_config_home} ${domain_name}\"",
+          command => "/bin/su -m -s /bin/bash - ${psft_runtime_user_name} -c \"${archive_location}/WebServer/Unix/asp_web.bin ${ps_config_home} ${domain_name}\"",
           creates => "${ps_config_home}/webserv/${domain_name}/applications/peoplesoft/PORTAL.war/WEB-INF/gsdocs",
         }
         -> file { "${ps_config_home}/webserv/${domain_name}/applications/peoplesoft/PORTAL.war/WEB-INF/lib/psjoa.jar" :
@@ -50,12 +50,11 @@ class io_erpfirewall::pia (
           path   => 'c:/temp',
         }
         -> exec { "${domain_name}_copy_erpfirewall_installer":
-          command  => "copy-item ${archive_location}/WebServer/Windows/gh_firewall_web.exe c:/temp",
-          # creates  => 'c:/temp/gh_firewall_web.exe',
+          command  => "copy-item ${archive_location}/WebServer/Windows/asp_web.exe c:/temp",
           provider => powershell,
         }
         -> exec { "${domain_name}_install_erpfirwall":
-          command  => "& \"c:/temp/gh_firewall_web.exe\" /log=\"c:/temp/erpfirewall-webserver-installation.log\" /verysilent /suppressmsgboxes /pshome=\"${ps_config_home}\" /piadomain=\"${udomain_name}\"; sleep 30",
+          command  => "& \"c:/temp/asp_web.exe\" /log=\"c:/temp/erpfirewall-webserver-installation.log\" /verysilent /suppressmsgboxes /pshome=\"${ps_config_home}\" /piadomain=\"${udomain_name}\"; sleep 30",
           creates  => "${ps_config_home}/webserv/${domain_name}/applications/peoplesoft/PORTAL.war/WEB-INF/gsdocs",
           provider => powershell,
         }


### PR DESCRIPTION
* Change from `hiera()` calls to now use `lookup()`
* Change installer names based on changes in `21E57` release
